### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,14 +47,14 @@ Quickstart
 3. Type like a madman.
 
 
-More at http://doitlive.readthedocs.io
---------------------------------------
+More at https://doitlive.readthedocs.io
+---------------------------------------
 
 Project Links
 -------------
 
-- Docs: http://doitlive.readthedocs.org/
-- Changelog: http://doitlive.readthedocs.org/en/latest/changelog.html
+- Docs: https://doitlive.readthedocs.io/
+- Changelog: https://doitlive.readthedocs.io/en/latest/changelog.html
 - PyPI: https://pypi.python.org/pypi/doitlive
 - Issues: https://github.com/sloria/doitlive/issues
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.