### PR TITLE
new line option {new_line} for prompt template

### DIFF
--- a/doitlive/__init__.py
+++ b/doitlive/__init__.py
@@ -210,6 +210,7 @@ R_ANGLE_DOUBLE = TermString(u'»')
 R_ARROW = TermString(u'➔')
 DOLLAR = TermString(u'$')
 PERCENT = TermString(u'%')
+NEW_LINE = TermString(u'\n')
 
 
 def get_prompt_state():
@@ -233,6 +234,7 @@ def get_prompt_state():
         'dollar': DOLLAR,
         'percent': PERCENT,
         'now': dt.datetime.now(),
+        'new_line': NEW_LINE,
         # ANSI values object
         'TTY': TTY,
     }


### PR DESCRIPTION
New option `{new_line}` that allows the use of `\n` in a prompt template.