### PR TITLE
Enforce minimum speed 1

### DIFF
--- a/doitlive/__init__.py
+++ b/doitlive/__init__.py
@@ -474,6 +474,7 @@ class SessionState(dict):
         self['envvars'].append(envvar)
 
     def set_speed(self, speed):
+        speed = speed if speed > 0 else 1
         self['speed'] = int(speed)
 
     def set_template(self, template):


### PR DESCRIPTION
Prevent problems if user passes `0` or a negative number for speed.

Thanks for writing this. :) I use it often at work and it greatly amuses my peers.