### PR TITLE
Implemented Stealth Mode Pausing and Resuming

### DIFF
--- a/doitlive/cli.py
+++ b/doitlive/cli.py
@@ -133,12 +133,13 @@ OPTION_MAP = {
 SHELL_RE = re.compile(r"```(python|ipython)")
 
 
-def stealthmode(command, state, is_run):
+def stealthmode(state, is_run):
     if not is_run:
         return 0
     continue_loop = True
+    echo("\r", nl=True)
     while continue_loop:
-        continue_loop = regularrun(command, **state)
+        continue_loop = regularrun(**state)
     return 1
 
 
@@ -243,7 +244,7 @@ def run(
             # goto_stealthmode determines when to switch to stealthmode
             goto_stealthmode = magicrun(command, **state)
             # stealthmode allows user to type live commands outside of automated script
-            i -= stealthmode(command, state, goto_stealthmode)
+            i -= stealthmode(state, goto_stealthmode)
     echo_prompt(state["prompt_template"])
     wait_for(RETURNS)
     if not quiet:

--- a/doitlive/keyboard.py
+++ b/doitlive/keyboard.py
@@ -137,7 +137,6 @@ def regulartype(prompt_template="default"):
     Returns: command_string |  The command to be passed to the shell to run. This is
                             |  typed by the user.
     """
-    echo("\r", nl=True)
     echo_prompt(prompt_template)
     command_string = ""
     cursor_position = 0
@@ -148,8 +147,7 @@ def regulartype(prompt_template="default"):
                 echo(carriage_return=True)
                 raise click.Abort()
             elif in_char == CTRLZ:
-                click.clear()
-                echo_prompt(prompt_template)
+                echo("\r", nl=True)
                 return in_char
             elif in_char == BACKSPACE:
                 if cursor_position > 0:
@@ -162,10 +160,6 @@ def regulartype(prompt_template="default"):
             elif in_char == CTRLZ and hasattr(signal, "SIGTSTP"):
                 # Background process
                 os.kill(0, signal.SIGTSTP)
-                # When doitlive is back in foreground, clear the terminal
-                # and resume where we left off
-                click.clear()
-                echo_prompt(prompt_template)
             else:
                 echo(in_char, nl=False)
                 command_string += in_char
@@ -173,7 +167,6 @@ def regulartype(prompt_template="default"):
 
 
 def regularrun(
-    text,
     shell,
     prompt_template="default",
     aliases=None,
@@ -189,7 +182,6 @@ def regularrun(
     command_string = regulartype(prompt_template)
     if command_string == CTRLZ:
         loop_again = False
-        click.clear()
         return loop_again
     run_command(
         command_string,

--- a/doitlive/keyboard.py
+++ b/doitlive/keyboard.py
@@ -18,6 +18,7 @@ ESC = "\x1b"
 BACKSPACE = "\x7f"
 CTRLC = "\x03"
 CTRLZ = "\x1a"
+TAB = "\x09"
 RETURNS = {"\r", "\n"}
 
 
@@ -46,7 +47,7 @@ def magictype(text, prompt_template="default", speed=1):
             if in_char in {ESC, CTRLC}:
                 echo(carriage_return=True)
                 raise click.Abort()
-            elif in_char == CTRLZ:
+            elif in_char == TAB:
                 return_to_regular_type = True
                 break
             elif in_char == BACKSPACE:
@@ -146,7 +147,7 @@ def regulartype(prompt_template="default"):
             if in_char in {ESC, CTRLC}:
                 echo(carriage_return=True)
                 raise click.Abort()
-            elif in_char == CTRLZ:
+            elif in_char == TAB:
                 echo("\r", nl=True)
                 return in_char
             elif in_char == BACKSPACE:
@@ -160,6 +161,10 @@ def regulartype(prompt_template="default"):
             elif in_char == CTRLZ and hasattr(signal, "SIGTSTP"):
                 # Background process
                 os.kill(0, signal.SIGTSTP)
+                # When doitlive is back in foreground, clear the terminal
+                # and resume where we left off
+                click.clear()
+                echo_prompt(prompt_template)
             else:
                 echo(in_char, nl=False)
                 command_string += in_char
@@ -180,7 +185,7 @@ def regularrun(
     """
     loop_again = True
     command_string = regulartype(prompt_template)
-    if command_string == CTRLZ:
+    if command_string == TAB:
         loop_again = False
         return loop_again
     run_command(


### PR DESCRIPTION
Added a stealth mode to pause and resume scenario silently. Stealth mode can be toggled by pressing CTRL-Z. Not currently implemented for the Python and IPython shells.

In response to Issue #113 