### PR TITLE
Add typed comments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
     exclude: docopt.py
     language_version: python3
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.7
+  rev: 3.7.8
   hooks:
   - id: flake8
 - repo: https://github.com/asottile/blacken-docs
-  rev: v0.5.0
+  rev: v1.3.0
   hooks:
   - id: blacken-docs
     additional_dependencies: [black==19.3b0]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,7 +107,12 @@ To view a list of available themes, run ``doitlive themes`` or ``doitlive themes
 Comment magic (configuration)
 -----------------------------
 
-Any line in a session file that begins with  ``#`` is a comment. Comments are ignored unless they begin with ``#doitlive``, in which case they are used to configure the session.
+Any line in a session file that begins with  ``#`` is a comment. Comments are ignored unless they begin with ``#doitlive``, in which case they are used to configure the session, or ``#dilc:``, in which case they are typed out.
+
+Example: ::
+
+    # This comment will be ignored and not shown at all.
+    #dilc: This comment will be typed out as a shell comment.
 
 The following options are available (all are optional).
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==2.1.2
+sphinx==2.2.0
 sphinx-issues==1.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==2.1.1
+sphinx==2.1.2
 sphinx-issues==1.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==2.0.1
+sphinx==2.1.0
 sphinx-issues==1.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==2.1.0
+sphinx==2.1.1
 sphinx-issues==1.2.0

--- a/doitlive/cli.py
+++ b/doitlive/cli.py
@@ -177,7 +177,14 @@ def run(
         i += 1
         if not command:
             continue
-        is_comment = command.startswith("#")
+
+        # Comments starting with "#dilc:" are meant to be typed out.
+        if command.startswith("#dilc:"):
+            is_comment = False
+            command = "#" + command[6:]
+        else:
+            is_comment = command.startswith("#")
+
         if not is_comment:
             command_as_list = shlex.split(ensure_utf8(command))
         else:

--- a/doitlive/cli.py
+++ b/doitlive/cli.py
@@ -178,19 +178,21 @@ def run(
         if not command:
             continue
 
-        # Comments starting with "#dilc:" are meant to be typed out.
-        if command.startswith("#dilc:"):
-            is_comment = False
-            command = "#" + command[6:]
-        else:
-            is_comment = command.startswith("#")
+        is_comment = command.startswith("#")
 
-        if not is_comment:
-            command_as_list = shlex.split(ensure_utf8(command))
-        else:
-            command_as_list = None
+        # Comments starting with "#dilc:" are meant to be typed out.
+        is_typed_comment = True if command.startswith("#dilc:") else False
+        command_as_list = None if is_comment else shlex.split(ensure_utf8(command))
+
         shell_match = SHELL_RE.match(command)
-        if is_comment:
+
+        if is_typed_comment:
+            magictype(
+                "#" + command[6:],
+                prompt_template=state["prompt_template"],
+                speed=state["speed"],
+            )
+        elif is_comment:
             # Parse comment magic
             match = OPTION_RE.match(command)
             if match:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ EXTRAS_REQUIRE = {
     "lint": [
         "flake8==3.7.8",
         'flake8-bugbear==19.3.0; python_version >= "3.5"',
-        "pre-commit==1.17.0",
+        "pre-commit==1.18.0",
     ],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ EXTRAS_REQUIRE = {
         'IPython==6.5.0; python_version >= "3"',
     ],
     "lint": [
-        "flake8==3.7.7",
+        "flake8==3.7.8",
         'flake8-bugbear==19.3.0; python_version >= "3.5"',
         "pre-commit==1.17.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ EXTRAS_REQUIRE = {
     "lint": [
         "flake8==3.7.8",
         'flake8-bugbear==19.8.0; python_version >= "3.5"',
-        "pre-commit==1.18.0",
+        "pre-commit==1.18.1",
     ],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ EXTRAS_REQUIRE = {
     "lint": [
         "flake8==3.7.8",
         'flake8-bugbear==19.8.0; python_version >= "3.5"',
-        "pre-commit==1.18.1",
+        "pre-commit==1.18.2",
     ],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ EXTRAS_REQUIRE = {
     "lint": [
         "flake8==3.7.7",
         'flake8-bugbear==19.3.0; python_version >= "3.5"',
-        "pre-commit==1.16.1",
+        "pre-commit==1.17.0",
     ],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ EXTRAS_REQUIRE = {
     ],
     "lint": [
         "flake8==3.7.8",
-        'flake8-bugbear==19.3.0; python_version >= "3.5"',
+        'flake8-bugbear==19.8.0; python_version >= "3.5"',
         "pre-commit==1.18.0",
     ],
 }

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ EXTRAS_REQUIRE = {
     "lint": [
         "flake8==3.7.8",
         'flake8-bugbear==19.8.0; python_version >= "3.5"',
-        "pre-commit==1.18.2",
+        "pre-commit==1.18.3",
     ],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]


### PR DESCRIPTION
I have added typed comments. Comments that start with `#dilc:` will get typed out as normal:

```
#dilc: This comment will get typed to the console with the `dilc:` part removed.
```