### PR TITLE
Support modern IPython

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
   - id: black
     exclude: docopt.py
     language_version: python3
+    additional_dependencies:
+      # Python 2 shenanigans. Black v20-21 is not compatible
+      # with click 8. But Black v22 is not compatible with Python 2.
+      - "click<8"
+
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.8.3
   hooks:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,3 +21,5 @@ Contributors (chronological)
 - Tristan Le Guern `@Aversiste <https://github.com/Aversiste>`_
 - John Lehett `@jlehett <https://github.com/jlehett>`_
 - Tim Gates `@timgates42 <https://github.com/timgates42>`_
+- Matan Rosenberg `@matan129 <https://github.com/matan129>`_
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,27 @@ variables:
 jobs:
 - template: job--python-tox.yml@sloria
   parameters:
-    toxenvs: [lint, py27, py36, py37, py38, py39]
+    toxenvs: [
+      lint,
+
+      py27-ipython5,
+      
+      py36-ipython5,
+      py36-ipython6,
+      py36-ipython7,
+
+      py37-ipython6,
+      py37-ipython7,
+
+      py38-ipython7,
+      py38-ipython8,
+
+      py39-ipython7,
+      py39-ipython8,
+
+      py310-ipython7,
+      py310-ipython8
+    ]
     os: linux
 - template: job--pypi-release.yml@sloria
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,16 +25,6 @@ jobs:
       
       py36-ipython5,
       py36-ipython6,
-      py36-ipython7,
-
-      py37-ipython6,
-      py37-ipython7,
-
-      py38-ipython7,
-      py38-ipython8,
-
-      py39-ipython7,
-      py39-ipython8,
 
       py310-ipython7,
       py310-ipython8

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -246,10 +246,6 @@ If you have `IPython <https://ipython.org/>`_ installed, you can run doitlive in
 
    ```
 
-.. note::
-
-   Only IPython>=5.0,<7.0 is supported.
-
 
 Shell completion
 ----------------

--- a/doitlive/cli.py
+++ b/doitlive/cli.py
@@ -229,12 +229,8 @@ def run(
             )
 
             if shell_name == "ipython":
-                try:
-                    from doitlive.ipython_consoles import start_ipython_player
-                except ImportError:
-                    raise RuntimeError(
-                        "```ipython blocks require IPython to be installed"
-                    )
+                from doitlive.ipython import start_ipython_player
+
                 # dedent all the commands to account for IPython's autoindentation
                 ipy_commands = [textwrap.dedent(cmd) for cmd in py_commands]
                 start_ipython_player(ipy_commands, speed=state["speed"])

--- a/doitlive/ipython/__init__.py
+++ b/doitlive/ipython/__init__.py
@@ -1,0 +1,23 @@
+import packaging.version
+
+
+def is_modern_ipython():
+    try:
+        import IPython
+    except ImportError:
+        raise RuntimeError("ipython blocks require IPython to be installed")
+
+    return packaging.version.parse(IPython.__version__) >= packaging.version.parse(
+        "7.0.0"
+    )
+
+
+def start_ipython_player(commands, speed):
+    if is_modern_ipython():
+        from doitlive.ipython.app import PlayerTerminalIPythonApp
+    else:
+        from doitlive.ipython.legacy_app import PlayerTerminalIPythonApp
+
+    PlayerTerminalIPythonApp.commands = commands
+    PlayerTerminalIPythonApp.speed = speed
+    PlayerTerminalIPythonApp.launch_instance()

--- a/doitlive/ipython/app.py
+++ b/doitlive/ipython/app.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+"""doitlive IPython support."""
+from __future__ import absolute_import, print_function
+
+import itertools as it
+
+from click import Abort
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from IPython.terminal.ipapp import TerminalIPythonApp
+
+from prompt_toolkit.key_binding import KeyPress
+from prompt_toolkit.keys import Keys
+
+from doitlive import RETURNS, wait_for, echo
+
+
+class DoitliveKeyProcessor:
+    def __init__(self, wrapped_processor, next_keys):
+        self.__wrapped = wrapped_processor
+        self.__next_keys = next_keys
+
+    def feed(self, key_press, first=False) -> None:
+        self.feed_multiple([key_press], first=first)
+
+    def feed_multiple(self, key_presses, first=False) -> None:
+        key_presses = self.__next_keys(key_presses)
+
+        if first:
+            self.__wrapped.input_queue.extendleft(reversed(key_presses))
+        else:
+            self.__wrapped.input_queue.extend(key_presses)
+
+    def __getattr__(self, item):
+        return getattr(self.__wrapped, item)
+
+
+class DoitliveTerminalInteractiveShell(TerminalInteractiveShell):
+    """A magic IPython terminal shell."""
+
+    def __init__(self, commands, speed=1, *args, **kwargs):
+        self.commands = commands or []
+        self.speed = speed
+
+        # Index of current command
+        self.current_command_index = 0
+        # Index of current character in current command
+        self.current_command_pos = 0
+
+        super(DoitliveTerminalInteractiveShell, self).__init__(*args, **kwargs)
+
+    def next_keys(self, key_presses):
+        return list(
+            it.chain.from_iterable(
+                [self._next_keys(key_press) for key_press in key_presses]
+            )
+        )
+
+    def _next_keys(self, key_press):
+        """Handles the magic typing when a key is pressed"""
+
+        if key_press.key in {Keys.Escape, Keys.ControlC}:
+            echo(carriage_return=True)
+            raise Abort()
+
+        if key_press.key == Keys.Backspace:
+            self.current_command_pos = max(0, self.current_command_pos - 1)
+            return [key_press]
+
+        if key_press.key == Keys.CPRResponse:
+            return []
+
+        if self.current_command_pos < len(self.current_command()):
+            current_keys = self.current_command_keys()
+            self.advance()
+            return [KeyPress(k) for k in current_keys]
+
+        # Command is finished, wait for Enter
+        if key_press.key != Keys.Enter:
+            return []
+
+        self.current_command_index += 1
+        self.current_command_pos = 0
+        return [key_press]
+
+    def current_command(self):
+        return self.commands[self.current_command_index]
+
+    def current_command_keys(self):
+        current_command = self.current_command()
+        end = min(self.current_command_pos + self.speed, len(current_command))
+        return current_command[self.current_command_pos : end]
+
+    def advance(self):
+        self.current_command_pos += min(
+            [self.speed, len(self.current_command()) - self.current_command_pos]
+        )
+
+    # Override TerminalInteractiveShell
+    # Much of this is copy-and-pasted from the parent class implementation
+    # due to lack of hooks
+    def interact(self):
+        self.keep_running = True
+        while self.keep_running:
+            print(self.separate_in, end="")
+
+            if self.current_command_index > len(self.commands) - 1:
+                echo("Do you really want to exit ([y]/n)? ", nl=False)
+                wait_for(RETURNS)
+                self.ask_exit()
+                return None
+
+            try:
+                code = self.prompt_for_code()
+            except EOFError:
+                if (not self.confirm_exit) or self.ask_yes_no(
+                    "Do you really want to exit ([y]/n)?", "y", "n"
+                ):
+                    self.ask_exit()
+
+            else:
+                if code:
+                    self.run_cell(code, store_history=True)
+
+    # Override TerminalInteractiveShell
+    def init_prompt_toolkit_cli(self):
+        super(DoitliveTerminalInteractiveShell, self).init_prompt_toolkit_cli()
+        self.pt_app.app.key_processor = DoitliveKeyProcessor(
+            wrapped_processor=self.pt_app.app.key_processor, next_keys=self.next_keys
+        )
+
+
+class PlayerTerminalIPythonApp(TerminalIPythonApp):
+    """IPython app that runs the PlayerTerminalInteractiveShell."""
+
+    commands = tuple()
+    speed = 1
+
+    # Ignore command line args, since this will be run from the doitlive CLI
+    def parse_command_line(self, argv=None):
+        return None
+
+    def init_shell(self):
+        """initialize the InteractiveShell instance"""
+        self.shell = DoitliveTerminalInteractiveShell.instance(
+            commands=self.commands,
+            speed=self.speed,
+            parent=self,
+            display_banner=False,
+            profile_dir=self.profile_dir,
+            ipython_dir=self.ipython_dir,
+            user_ns=self.user_ns,
+        )
+        self.shell.configurables.append(self)

--- a/doitlive/ipython/legacy_app.py
+++ b/doitlive/ipython/legacy_app.py
@@ -164,10 +164,3 @@ class PlayerTerminalIPythonApp(TerminalIPythonApp):
             user_ns=self.user_ns,
         )
         self.shell.configurables.append(self)
-
-
-def start_ipython_player(commands, speed=1):
-    """Starts a new magic IPython shell."""
-    PlayerTerminalIPythonApp.commands = commands
-    PlayerTerminalIPythonApp.speed = speed
-    PlayerTerminalIPythonApp.launch_instance()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup
 
 
-INSTALL_REQUIRES = ["click>=4.0", "click-completion>=0.3.1", "click-didyoumean>=0.0.3"]
+INSTALL_REQUIRES = ["click>=4.0", "click-completion>=0.3.1", "click-didyoumean>=0.0.3", "packaging"]
 
 if "win32" in str(sys.platform).lower():
     # Terminal colors for Windows
@@ -13,9 +13,7 @@ if "win32" in str(sys.platform).lower():
 
 EXTRAS_REQUIRE = {
     "tests": [
-        "pytest",
-        'IPython<6; python_version < "3"',
-        'IPython==6.5.0; python_version >= "3"',
+        "pytest"
     ],
     "lint": [
         "flake8==3.9.2",

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,19 @@ import sys
 from setuptools import setup
 
 
-INSTALL_REQUIRES = ["click>=4.0", "click-completion>=0.3.1", "click-didyoumean>=0.0.3", "packaging"]
+INSTALL_REQUIRES = [
+    "click>=4.0,<8",
+    "click-completion>=0.3.1",
+    "click-didyoumean>=0.0.3",
+    "packaging",
+]
 
 if "win32" in str(sys.platform).lower():
     # Terminal colors for Windows
     INSTALL_REQUIRES.append("colorama>=0.2.4")
 
 EXTRAS_REQUIRE = {
-    "tests": [
-        "pytest"
-    ],
+    "tests": ["pytest", "IPython"],
     "lint": [
         "flake8==3.9.2",
         'flake8-bugbear==20.11.1; python_version >= "3.5"',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,17 @@ import pytest
 from click.testing import CliRunner
 
 import doitlive
+import doitlive.ipython
 
 
 @pytest.fixture(scope="session")
 def runner():
     doitlive.cli.TESTING = True
     return CliRunner()
+
+
+def pytest_ignore_collect(path, config):
+    if doitlive.ipython.is_modern_ipython():
+        return path.basename == "test_ipython_legacy.py"
+
+    return path.basename == "test_ipython.py"

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 import os
 import click
 import pytest
-from prompt_toolkit.key_binding.input_processor import KeyPress
+from prompt_toolkit.key_binding import KeyPress
 from prompt_toolkit.keys import Keys
 
-from doitlive.ipython_consoles import PlayerTerminalInteractiveShell
+from doitlive.ipython.app import DoitliveTerminalInteractiveShell
 
 
 @pytest.mark.skipif(
@@ -18,7 +18,7 @@ class TestPlayerTerminalInteractiveShell:
     @pytest.fixture()
     def make_shell(self):
         def func(commands, speed=1):
-            shell = PlayerTerminalInteractiveShell(commands=commands, speed=speed)
+            shell = DoitliveTerminalInteractiveShell(commands=commands, speed=speed)
             shell.init_prompt_toolkit_cli()
             return shell
 
@@ -29,64 +29,64 @@ class TestPlayerTerminalInteractiveShell:
         return make_shell(commands=["import math", "1 + 1"])
 
     def test_current_command(self, shell):
-        assert shell.current_command == "import math"
+        assert shell.current_command() == "import math"
         shell.current_command_index += 1
-        assert shell.current_command == "1 + 1"
+        assert shell.current_command() == "1 + 1"
 
     def test_current_command_key(self, shell):
-        assert shell.current_command_key == "i"
+        assert shell.current_command_keys() == "i"
         shell.current_command_pos += 1
-        assert shell.current_command_key == "m"
+        assert shell.current_command_keys() == "m"
 
     def test_on_feed_key(self, shell):
-        assert shell.current_command_key == "i"
+        assert shell.current_command_keys() == "i"
         key_press = KeyPress("x")
-        shell.on_feed_key(key_press)
-        assert shell.current_command_key == "m"
+        shell.next_keys([key_press])
+        assert shell.current_command_keys() == "m"
 
     def test_on_feed_key_goes_to_next_command_after_enter(self, shell):
-        assert shell.current_command_key == "i"
+        assert shell.current_command_keys() == "i"
         for _ in range(len("import math")):
-            shell.on_feed_key(KeyPress("x"))
-        shell.on_feed_key(KeyPress(Keys.Enter))
-        assert shell.current_command == "1 + 1"
+            shell.next_keys([KeyPress("x")])
+        shell.next_keys([KeyPress(Keys.Enter)])
+        assert shell.current_command() == "1 + 1"
 
     def test_assert_on_feed_key_with_speed(self, make_shell):
         shell = make_shell(commands=["import math", "1 + 1"], speed=2)
-        assert shell.current_command_key == "im"
-        shell.on_feed_key(KeyPress("x"))
-        assert shell.current_command_key == "po"
+        assert shell.current_command_keys() == "im"
+        shell.next_keys([KeyPress("x")])
+        assert shell.current_command_keys() == "po"
 
     def test_on_feed_key_escape_aborts(self, shell):
         with pytest.raises(click.Abort):
-            shell.on_feed_key(KeyPress(Keys.Escape))
+            shell.next_keys([KeyPress(Keys.Escape)])
 
     def test_on_feed_key_ctrlc_aborts(self, shell):
         with pytest.raises(click.Abort):
-            shell.on_feed_key(KeyPress(Keys.ControlC))
+            shell.next_keys([KeyPress(Keys.ControlC)])
 
     def test_on_feed_key_backspace(self, shell):
-        shell.on_feed_key(KeyPress("x"))
-        assert shell.current_command_key == "m"
-        shell.on_feed_key(KeyPress(Keys.Backspace))
-        assert shell.current_command_key == "i"
-        shell.on_feed_key(KeyPress(Keys.Backspace))
-        assert shell.current_command_key == "i"
+        shell.next_keys([KeyPress("x")])
+        assert shell.current_command_keys() == "m"
+        shell.next_keys([KeyPress(Keys.Backspace)])
+        assert shell.current_command_keys() == "i"
+        shell.next_keys([KeyPress(Keys.Backspace)])
+        assert shell.current_command_keys() == "i"
 
     def test_on_feed_key_backspace_with_speed(self, make_shell):
         shell = make_shell(commands=["1+1"], speed=2)
-        shell.on_feed_key(KeyPress("x"))
-        assert shell.current_command_key == "1"
-        shell.on_feed_key(KeyPress(Keys.Backspace))
-        assert shell.current_command_key == "+1"
+        shell.next_keys([KeyPress("x")])
+        assert shell.current_command_keys() == "1"
+        shell.next_keys([KeyPress(Keys.Backspace)])
+        assert shell.current_command_keys() == "+1"
 
     def test_on_feed_key_does_not_increment_pos_past_length_of_command(
         self, make_shell
     ):
-        shell = make_shell(commands=["1+1"], speed=2)
-        shell.on_feed_key(KeyPress("xx"))
-        assert shell.current_command_pos == len("1+1") - 1
-        shell.on_feed_key(KeyPress("x"))
-        assert shell.current_command_pos == len("1+1")
-        shell.on_feed_key(KeyPress("x"))
-        assert shell.current_command_pos == len("1+1")
+        shell = make_shell(commands=["abcde"], speed=2)
+        shell.next_keys([KeyPress("x"), KeyPress("x")])
+        assert shell.current_command_pos == len("abcde") - 1
+        shell.next_keys([KeyPress("x")])
+        assert shell.current_command_pos == len("abcde")
+        shell.next_keys([KeyPress("x")])
+        assert shell.current_command_pos == len("abcde")

--- a/tests/test_ipython_legacy.py
+++ b/tests/test_ipython_legacy.py
@@ -1,0 +1,92 @@
+from __future__ import unicode_literals
+
+import os
+import click
+import pytest
+from prompt_toolkit.key_binding.input_processor import KeyPress
+from prompt_toolkit.keys import Keys
+
+from doitlive.ipython.legacy_app import PlayerTerminalInteractiveShell
+
+
+@pytest.mark.skipif(
+    # FIXME
+    "CI" in os.environ,
+    reason="IPython shell does not work in Azure Pipelines",
+)
+class TestPlayerTerminalInteractiveShell:
+    @pytest.fixture()
+    def make_shell(self):
+        def func(commands, speed=1):
+            shell = PlayerTerminalInteractiveShell(commands=commands, speed=speed)
+            shell.init_prompt_toolkit_cli()
+            return shell
+
+        return func
+
+    @pytest.fixture()
+    def shell(self, make_shell):
+        return make_shell(commands=["import math", "1 + 1"])
+
+    def test_current_command(self, shell):
+        assert shell.current_command == "import math"
+        shell.current_command_index += 1
+        assert shell.current_command == "1 + 1"
+
+    def test_current_command_key(self, shell):
+        assert shell.current_command_key == "i"
+        shell.current_command_pos += 1
+        assert shell.current_command_key == "m"
+
+    def test_on_feed_key(self, shell):
+        assert shell.current_command_key == "i"
+        key_press = KeyPress("x")
+        shell.on_feed_key(key_press)
+        assert shell.current_command_key == "m"
+
+    def test_on_feed_key_goes_to_next_command_after_enter(self, shell):
+        assert shell.current_command_key == "i"
+        for _ in range(len("import math")):
+            shell.on_feed_key(KeyPress("x"))
+        shell.on_feed_key(KeyPress(Keys.Enter))
+        assert shell.current_command == "1 + 1"
+
+    def test_assert_on_feed_key_with_speed(self, make_shell):
+        shell = make_shell(commands=["import math", "1 + 1"], speed=2)
+        assert shell.current_command_key == "im"
+        shell.on_feed_key(KeyPress("x"))
+        assert shell.current_command_key == "po"
+
+    def test_on_feed_key_escape_aborts(self, shell):
+        with pytest.raises(click.Abort):
+            shell.on_feed_key(KeyPress(Keys.Escape))
+
+    def test_on_feed_key_ctrlc_aborts(self, shell):
+        with pytest.raises(click.Abort):
+            shell.on_feed_key(KeyPress(Keys.ControlC))
+
+    def test_on_feed_key_backspace(self, shell):
+        shell.on_feed_key(KeyPress("x"))
+        assert shell.current_command_key == "m"
+        shell.on_feed_key(KeyPress(Keys.Backspace))
+        assert shell.current_command_key == "i"
+        shell.on_feed_key(KeyPress(Keys.Backspace))
+        assert shell.current_command_key == "i"
+
+    def test_on_feed_key_backspace_with_speed(self, make_shell):
+        shell = make_shell(commands=["1+1"], speed=2)
+        shell.on_feed_key(KeyPress("x"))
+        assert shell.current_command_key == "1"
+        shell.on_feed_key(KeyPress(Keys.Backspace))
+        assert shell.current_command_key == "+1"
+
+    def test_on_feed_key_does_not_increment_pos_past_length_of_command(
+        self, make_shell
+    ):
+        shell = make_shell(commands=["1+1"], speed=2)
+        shell.on_feed_key(KeyPress("xx"))
+        assert shell.current_command_pos == len("1+1") - 1
+        shell.on_feed_key(KeyPress("x"))
+        assert shell.current_command_pos == len("1+1")
+        shell.on_feed_key(KeyPress("x"))
+        assert shell.current_command_pos == len("1+1")

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,13 @@
 [tox]
-envlist = lint,py27,py35,py36,py37,py38,py39,docs
+envlist = lint,docs,py27-ipython5,py35-ipython{5,6,7},py36-ipython{5,6,7},py37-ipython{6,7},py3{8,9,10}-ipython{7,8}
 
 [testenv]
+deps:
+  ipython5: IPython>=5,<6
+  ipython6: IPython>=6,<7
+  ipython7: IPython>=7,<8
+  ipython8: IPython>=8
+
 extras = tests
 commands = pytest -s {posargs}
 passenv = HOME SHELL CI

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps:
 
 extras = tests
 commands = pytest -s {posargs}
-passenv = HOME SHELL CI
+passenv = HOME SHELL CI DOITLIVE_INTERPRETER
 
 [testenv:lint]
 deps = pre-commit~=1.14


### PR DESCRIPTION
Solves #91!

I had to jump through hoops to keep everything compatible with Python 2. It might be a good idea to remove support for it all together and bump the major version of `doitlive`. 
