### PR TITLE
new feature: Anchors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -200,6 +200,13 @@ unsets an environment variable.
 
 Whether to echo comments or not. If enabled, non-magic comments will be echoed back in bold yellow before each prompt. This can be useful for providing some annotations for yourself and the audience.
 
+#doitlive anchor: <name>
+************************
+
+anchors can be used to mark sections in the .sh file. 
+Command line arguments ``--from-anchor`` and ``--to-anchor`` can then be used to restrict the play to just the commands between those 2 anchors.
+Each of those is optional, and if missing, will be the start and end of the file (as normal)
+
 
 Python mode
 -----------

--- a/doitlive/cli.py
+++ b/doitlive/cli.py
@@ -126,7 +126,6 @@ class SessionState(dict):
             self["commentecho"] = doit in self.TRUTHY
         return self["commentecho"]
 
-
 # Map of option names => function that modifies session state
 OPTION_MAP = {
     "prompt": lambda state, arg: state.set_template(arg),
@@ -206,8 +205,8 @@ def run(
                 func(state, arg)
             elif state.commentecho():
                 if state["do_process"]:
-                     comment = command.lstrip("#")
-                     secho(comment, fg="yellow", bold=True)
+                    comment = command.lstrip("#")
+                    secho(comment, fg="yellow", bold=True)
             continue
         elif not state["do_process"]:
             continue
@@ -259,6 +258,10 @@ def run(
             i -= stealthmode(state, goto_stealthmode)
     echo_prompt(state["prompt_template"])
     wait_for(RETURNS)
+    if not state['do_process']:
+        secho("NO COMMAND WAS PROCESSED. Anchors provided were probably not found", fg="red", bold=True)
+        return
+    
     if not quiet:
         secho("FINISHED SESSION", fg="yellow", bold=True)
 

--- a/doitlive/keyboard.py
+++ b/doitlive/keyboard.py
@@ -206,6 +206,7 @@ def magicrun(
     speed=1,
     test_mode=False,
     commentecho=False,
+    **kwargs
 ):
     """Echo out each character in ``text`` as keyboard characters are pressed,
     wait for a RETURN keypress, then run the ``text`` in a shell context.

--- a/examples/anchors.sh
+++ b/examples/anchors.sh
@@ -1,0 +1,42 @@
+#doitlive shell: /bin/bash
+#doitlive prompt: default
+#doitlive speed: 2
+#doitlive commentecho: true
+
+echo 'Hello there!'
+
+echo "Let's get started. There is an anchor named 'anchor1 after this string."
+
+#doitlive anchor: start
+
+echo "There is an anchor 'start' before this line. Any commands before it will not have been executed, if --from_anchor was set to 'start' at the command line"
+
+doitlive -h
+
+# doitlive anchor: themes
+
+doitlive themes -p
+
+clear
+
+# doitlive anchor: python
+
+# And now for something completely different
+
+echo 'We can even enter a Python console'
+
+```python
+list = [2, 4, 6, 8]
+sum = 0
+for num in list:
+    sum = sum + num
+
+print("The sum is: {sum}".format(sum=sum))
+```
+
+#doitlive speed: 2
+echo 'Pretty neat, eh?'
+
+echo 'Did you notice that the speed changed?'
+
+echo 'For full docs, check out:' $DOCS_URL


### PR DESCRIPTION
Anchors allow the user to define markers in the .sh file, and then use options on the `play` command to only go through a subset of the commands. 
This is massively useful for anyone building any large script file and wanting to be able to just show a part of it (or troubleshoot a part of his/her script)